### PR TITLE
Forward repr

### DIFF
--- a/parcon/__init__.py
+++ b/parcon/__init__.py
@@ -1573,7 +1573,10 @@ class Forward(_GRParser):
         return _rr.create_railroad(self.parser, options)
     
     def __repr__(self):
-        return "Forward()"
+        if self.parser is None:
+            return "Forward()"
+        else:
+            return "Forward(%s)" % self.parser
 
 
 class InfixExpr(_GRParser):

--- a/parcon/__init__.py
+++ b/parcon/__init__.py
@@ -500,9 +500,10 @@ def format_failure_with_context(expected, string):
     w = 37
     context_string = string[max(0, position - w):position + w]
     marker_pos = min(position, w)
-    marker_string = " " * marker_pos + "^"
-    return "%s\n  %r\n   %s" % (
-        formatted_expectations, context_string, marker_string)
+    marker_spacer = ''.join(
+        ' ' * (len(repr(c)) - 2) for c in context_string[:marker_pos])
+    return "%s\n  %r\n   %s^" % (
+        formatted_expectations, context_string, marker_spacer)
 
 
 def parse_space(text, position, end, space):

--- a/parcon/__init__.py
+++ b/parcon/__init__.py
@@ -493,6 +493,18 @@ def format_failure(expected):
     return format_expectations(position, expectations)
 
 
+def format_failure_with_context(expected, string):
+    position, expectations = filter_expectations(expected)
+    expectations = stringify_expectations(expectations)
+    formatted_expectations = format_expectations(position, expectations)
+    w = 37
+    context_string = string[max(0, position - w):position + w]
+    marker_pos = min(position, w)
+    marker_string = " " * marker_pos + "^"
+    return "%s\n  %r\n   %s" % (
+        formatted_expectations, context_string, marker_string)
+
+
 def parse_space(text, position, end, space):
     """
     Repeatedly applies the specified whitespace parser to the specified text
@@ -638,8 +650,11 @@ class Parser(object):
             # and if it is, we return the value.
             if whitespace.consume(string, result.end, len(string)) == len(string):
                 return result.value
-        raise ParseException("Parse failure: " + format_failure(result.expected), result.expected)
-    
+        raise ParseException(
+            "Parse failure: " + format_failure_with_context(
+                result.expected, string),
+            result.expected)
+
     def consume(self, text, position, end):
         result = self.parse(text, position, end, Invalid())
         while result:


### PR DESCRIPTION
This updates the repr for a `Forward` parser to include its sub-parser, if present, just like `Then` does. Useful for debugging :-)