### PR TITLE
Introduce NonConsumingExact which doesn't consume whitespace at the beginning of the string

### DIFF
--- a/parcon/__init__.py
+++ b/parcon/__init__.py
@@ -1344,6 +1344,15 @@ class Exact(_GRParser):
         return "Exact(" + repr(self.parser) + ")"
 
 
+class NonConsumingExact(Exact):
+    """
+    Like Exact(), except that it does not use the whitespace argument of
+    parse_string() to consume leading whitespace.
+    """
+    def parse(self, text, position, end, space):
+        return self.parser.parse(text, position, end, self.space_parser)
+
+
 class Optional(_GRParser):
     """
     A parser that returns whatever its underlying parser returns, except that

--- a/parcon/tests.py
+++ b/parcon/tests.py
@@ -44,6 +44,24 @@ def case(): #@DuplicatedSignature
     assert x.parse_string("5") == 5
 
 
+@test(parcon.Exact)
+def case(): #@DuplicatedSignature
+    ws = parcon.Word(parcon.whitespace)
+    x = parcon.Exact(parcon.alpha_word + ws + parcon.alpha_word)
+    assert x.parse_string('foo \t\r\n bar') == ('foo', ' \t\r\n ', 'bar')
+    x = parcon.Exact(ws + parcon.alpha_word)
+    assert (
+        x.parse_string(' \t\r\n bar', whitespace=parcon.Word(' ')) ==
+        ('\t\r\n ', 'bar'))
+
+
+@test(parcon.Invalid)
+def case(): #@DuplicatedSignature
+    x = (parcon.Word(parcon.whitespace) + parcon.alpha_word)
+    assert (
+        x.parse_string(' \t bar', whitespace=parcon.Invalid()) ==
+        (' \t ', 'bar'))
+
 def run_tests():
     targets = set()
     targets |= set(subclasses_in_module(parcon.Parser, ("parcon",)))

--- a/parcon/tests.py
+++ b/parcon/tests.py
@@ -55,6 +55,13 @@ def case(): #@DuplicatedSignature
         ('\t\r\n ', 'bar'))
 
 
+@test(parcon.NonConsumingExact)
+def case(): #@DuplicatedSignature
+    ws = parcon.Word(parcon.whitespace)
+    x = parcon.NonConsumingExact(ws + parcon.alpha_word)
+    assert x.parse_string(' \t\r\n bar') == (' \t\r\n ', 'bar')
+
+
 @test(parcon.Invalid)
 def case(): #@DuplicatedSignature
     x = (parcon.Word(parcon.whitespace) + parcon.alpha_word)


### PR DESCRIPTION
`parcon.Exact` doesn't play nicely out-of-the-box when trying to match whitespace at the start of a string. I've added some tests for the existing behaviour, including using `thing.parse_string(s, whitespace=parcon.Invalid())`, but I also wanted something which didn't require explicitly passing in the `whitespace` argument, hence creating `parcon.NonConsumingExact`. The only difference is that it doesn't bother to do `space.consume(...)` (which `parcon.Exact.parse` does do).

Also, naming things is hard; I don't really like this name, but it's 11pm and I couldn't come up with anything better.
