### PR TITLE
Fix for expressions containing Keyword not successfully graphing.

### DIFF
--- a/parcon/__init__.py
+++ b/parcon/__init__.py
@@ -1475,9 +1475,9 @@ class Keyword(_GRParser):
     
     def do_graph(self, graph):
         graph.add_node(id(self), label="Keyword")
-        graph.add_node(id(self), id(self.parser), label="parser")
+        graph.add_edge(id(self), id(self.parser), label="parser")
         if self.terminator is not None:
-            graph.add_node(id(self), id(self.terminator), label="terminator")
+            graph.add_edge(id(self), id(self.terminator), label="terminator")
         return [self.parser] + [self.terminator] if self.terminator is not None else []
     
     def create_railroad(self, options):


### PR DESCRIPTION
Hi,

When trying to graph a Keyword() instance, an exception is thrown.

Sample code:
```
> from parcon import *
> Keyword(Literal('a'), Literal('b')).graph()

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "parcon/graph.py", line 57, in graph
    new_list += graphable.do_graph(graph)
  File "parcon/__init__.py", line 1478, in do_graph
    graph.add_node(id(self), id(self.parser), label="parser")
TypeError: add_node() takes exactly 2 arguments (4 given)
````