### PR TITLE
Fix thread import error

### DIFF
--- a/parcon/ordered_dict.py
+++ b/parcon/ordered_dict.py
@@ -8,12 +8,15 @@
 
 import six
 try:
-    from thread import get_ident as _get_ident
+    from _thread import get_ident as _get_ident
 except ImportError:
     try:
-        from dummy_thread import get_ident as _get_ident
+        from thread import get_ident as _get_ident
     except ImportError:
-        from _dummy_thread import get_ident as _get_ident
+        try:
+            from dummy_thread import get_ident as _get_ident
+        except ImportError:
+            from _dummy_thread import get_ident as _get_ident
 
 try:
     from _abcoll import KeysView, ValuesView, ItemsView


### PR DESCRIPTION
On newer Python versions, `thread` module was renamed to `threading` and low level functions are available in `_thread` module. Thats why `ordered_dict.py` backport fails on newer Python versions (e.g. Python 3.10.x) trying to import `thread`.
This PR fixes this by trying to import `_threads` first, then falling back to other options ...